### PR TITLE
Improving Language and Clarity of ReadME.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 [![Join the chat at https://gitter.im/luisvinicius167/godux](https://badges.gitter.im/luisvinicius167/godux.svg)](https://gitter.im/luisvinicius167/godux?utm_source=badge&utm_medium=badge&utm_campaign=pr-badge&utm_content=badge)
 [![Go Report Card](https://goreportcard.com/badge/github.com/luisvinicius167/godux)](https://goreportcard.com/report/github.com/luisvinicius167/godux)
-> State Management for Go Backend applications inspired in Redux.
+> State Management for Go Backend applications inspired by Redux.
 
 <p align="center">
   <img src="img/godux_.png" alt="Godux">
@@ -21,16 +21,16 @@
 * Go: ``` go get github.com/luisvinicius167/godux ```
 
 ### Data Flow
-**godux** turns your data flow unidirectional:
+**godux** gives go unidirectional data flow:
 
-* Create actions as pure functions.
-* The Store dispatches actions.
-* Return new Value based on your Store State.
+* The Action returns a small map with specific directions that are dispatched to a Reducer.
+* The Reducer is a pure function (pure functions don't change original arguments) if relevant to it returns a new Value.
+* The Value becomes the new State of the Store.
 
 ### Principles:
-* Application State is held in the store, as a single map.
-* State is ready-only.
-* Changes are made with pure functions.
+* Global application state is held in the Store, as a single map.
+* State is ready-only (only *change* it only by *replacing* it with the Reducer).
+* Changes are made with pure functions - Actions/Reducers that do not change the actual object but make a changed copy.
 
 ### Store:
 A Store is basically a container that holds your application state.
@@ -42,7 +42,7 @@ A Store is basically a container that holds your application state.
 ```
 
 #### Action
-Actions are just pure functions. Your Actions functions always return a godux.Action. 
+Actions are just pure functions which pass on their inputs when they're dispatched. Actions are stored on the `godux` map as `godux.Action`. 
 
 ```go
     increment := func(number int) godux.Action {
@@ -53,7 +53,11 @@ Actions are just pure functions. Your Actions functions always return a godux.Ac
 	}
 ```
 ### Reducers
-Like Redux Concept: "Actions describe the fact that something happened, but don’t specify how the application’s state changes in response. This is the job of a reducer."
+As in Redux: 
+> "Actions describe the fact that something happened, but don’t specify how the application’s state changes in response. This is the job of a reducer". 
+
+Reducers are *pure* functions that take in actions and the state of the store as inputs and leave them all as they came in (aka. pure)-- especially the original state of the store must not be modified (it's accessed by `store.GetState`)).
+
 ```go
     // reducer function
 	reducer := func(action godux.Action) interface{} {
@@ -70,7 +74,7 @@ Like Redux Concept: "Actions describe the fact that something happened, but don�
 	store.Reducer(reducer)
 ```
 #### Dispatch
-Dispatch an action is very easy.
+Dispatching an action is very easy.
 ```go
     // Receive new value
 	newCount := store.Dispatch(increment(1)) // return 2
@@ -79,19 +83,19 @@ Dispatch an action is very easy.
 ### API Reference
 
 * #### Store:
-  * `` godux.newStore() ```: Create a single store with the state of your application.
-  * `` godux.SetState(name string, value interface{}) ```: Sets the state store.
-  * `` godux.GetState(name string) ```: Return your Store state value.
-  * `` godux.GetAllState() ```: Return whole state as a map.
+  * ` godux.newStore() `: Create a single store with the state of your application (should only be used once).
+  * ` godux.SetState(name string, value interface{}) `: Sets the state of the store.
+  * ` godux.GetState(name string) `: Return a state's value.
+  * ` godux.GetAllState() `: Return the whole state as a map.
 
-* #### Store Reducer:
-  * ``` store.Reducer(func(action godux.Action)) ```: Add the reducer function to your Store.
+* ##### Reducer:
+  * ``` store.Reducer(func(action godux.Action)) ```: Adding a reducer function to your Store.
 
-* #### Store Dispatch:
-  * ``` store.Dispatch(action godux.Action) ```: Dispatch your action to your Reducer.
+* ##### Dispatch:
+  * ``` store.Dispatch(action godux.Action) ```: Dispatching an action to your Reducer.
 
 * #### Action:
-  * ``` godux.Action( Type string, Value interface{}) ```: Your application action.
+  * ``` godux.Action( Type string, Value interface{}) ```: Adding an easily available Action.
 
 ### License
 MIT License.


### PR DESCRIPTION
- [x] Fixes english syntax errors.
- [x] Fixes markdown syntax errors.
- [x] Makes (hopefully) easier to understand.
- [ ] Still could use less repetitiveness.
- [ ] Could use more examples in the API Reference Guide.